### PR TITLE
chore(ci): pin base-ci v2026.5 + migrate ssh-deploy + release smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,42 @@ jobs:
       l3-command: "bun run test:e2e:bdd"
       l3-browser: "chromium"
     secrets: inherit
+
+  release-smoke:
+    name: Release Workflow Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install actionlint
+        run: |
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          sudo mv actionlint /usr/local/bin/
+
+      - name: Lint release.yml
+        run: actionlint .github/workflows/release.yml
+
+      - name: Assert ssh-deploy is SHA-pinned
+        run: |
+          if grep -q 'appleboy/ssh-action' .github/workflows/release.yml; then
+            echo "::error::release.yml still references appleboy/ssh-action"
+            exit 1
+          fi
+          if ! grep -q 'nocoo/base-ci/.github/actions/ssh-deploy@[a-f0-9]\{40\}' .github/workflows/release.yml; then
+            echo "::error::ssh-deploy must be pinned to a 40-char commit SHA"
+            exit 1
+          fi
+          echo "✅ ssh-deploy SHA-pinned, no appleboy reference"
+
+      - name: Assert base-ci is SHA-pinned
+        run: |
+          if grep -rE 'nocoo/base-ci.*@v[0-9]' .github/workflows/; then
+            echo "::error::Found floating tag reference to base-ci"
+            exit 1
+          fi
+          echo "✅ All base-ci references SHA-pinned"
+
+      - name: yamllint release.yml
+        run: |
+          pip install --quiet yamllint
+          yamllint -d "{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}" .github/workflows/release.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
     with:
       ignore-scripts: true
       pre-command: "bun run build"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,12 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Deploy to jp2.nocoo.cloud
-        uses: appleboy/ssh-action@v1
+        uses: nocoo/base-ci/.github/actions/ssh-deploy@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
         env:
           IMAGE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
         with:
           host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
+          user: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           port: ${{ secrets.VPS_PORT }}
           envs: IMAGE_SHA


### PR DESCRIPTION
## Summary

Implements [STU-904](mention://issue/320f7c48-8f08-491e-aac8-1b6fcd5950ea) — three atomic Conventional Commits:

1. `chore(ci): pin base-ci reusable workflow to v2026.5 SHA` — `bun-quality.yml` is now SHA-pinned to `aec4adc1a817c56790d1698329ef9398a15a754a` (v2026.5).
2. `feat(deploy): migrate from appleboy/ssh-action to in-house ssh-deploy@v2026.5` — `release.yml` swaps `appleboy/ssh-action@v1` → `nocoo/base-ci/.github/actions/ssh-deploy@<sha>`. Only input rename: `username` → `user`. `script` / `envs` / `key` / `host` / `port` unchanged.
3. `test(ci): add release.yml smoke test job (actionlint + SHA-pin assertions)` — adds independent `release-smoke` job to `ci.yml`: `actionlint` + grep assertions that ssh-deploy is SHA-pinned and no `appleboy` reference remains + yamllint on `release.yml`. Runs in parallel with `quality`, no `needs:`.

## Acceptance

- ✅ `grep -rn nocoo/base-ci .github/workflows/` → all SHA-pinned to v2026.5
- ✅ `grep -rE appleboy .github/workflows/` → only assertion text (no `uses:`)
- ✅ `release.yml` ssh-deploy is 40-char SHA pin
- ✅ `ci.yml` has `release-smoke` job
- ✅ `actionlint .github/workflows/*.yml` clean (verified locally)
- ✅ `release.yml` deploy `script:` business logic (healthcheck, docker commands) unchanged

## Test Plan

- [ ] CI quality job passes
- [ ] `release-smoke` job passes (actionlint + assertions + yamllint)